### PR TITLE
docs(release): fix typos in release categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,10 +9,10 @@ changelog:
     - title: 🐛 Bug Fixes
       labels:
       - bug
-    - title: ⚡️ Performance Improvments
+    - title: ⚡️ Performance Improvements
       labels:
       - performance
-    - title: 🗒️ Documentations
+    - title: 🗒️ Documentation
       labels:
       - documentation
     - title: 💄 UI Styles


### PR DESCRIPTION
## Summary
- fix typos in release categories for `Performance Improvements` and `Documentation`

## Testing
- `git status --short`