### PR TITLE
Update LangVersion and README grammar

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
   <!-- Common Build Properties -->
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <Deterministic>true</Deterministic>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A [ResoniteModLoader](https://github.com/resonite-modding-group/ResoniteModLoade
 
 ### Install to `rml_mods` Directory (and `rml_mods/HotReloadMods`)
 
-The project includes custom a target **Install** for development convenience:
+The project includes a custom target **Install** for development convenience:
 
 ```bash
 dotnet build -t:Install


### PR DESCRIPTION
## Summary
- set `LangVersion` to `latest`
- fix README grammar for `Install` section

## Testing
- `dotnet build -v q` *(fails: missing Resonite assemblies)*