### PR TITLE
Fix ResonitePath normalization and install copy

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,6 +51,11 @@
     <ResonitePath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</ResonitePath>
   </PropertyGroup>
 
+  <!-- Normalize ResonitePath -->
+  <PropertyGroup>
+    <ResonitePath>$([MSBuild]::EnsureTrailingSlash('$(ResonitePath)'))</ResonitePath>
+  </PropertyGroup>
+
   <!-- Derived Resonite Paths -->
   <PropertyGroup>
     <ResoniteManagedPath>$(ResonitePath)Resonite_Data\Managed\</ResoniteManagedPath>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,8 +19,7 @@
     <Message Text="Installing $(TargetFileName) to Resonite mods folder: $(ResoniteModsPath)" Importance="high" />
     <MakeDir Directories="$(ResoniteModsPath)" Condition="!Exists('$(ResoniteModsPath)')" />
     <Copy SourceFiles="$(TargetPath)"
-          DestinationFolder="$(ResoniteModsPath)"
-          SkipUnchangedFiles="true" />
+          DestinationFolder="$(ResoniteModsPath)" />
 
     <!-- Additionally install to HotReload folder for Debug builds -->
     <Message Text="Installing $(TargetFileName) to Resonite hot reload folder: $(ResoniteHotReloadPath)"
@@ -30,7 +29,6 @@
              Condition="'$(Configuration)'=='Debug' AND !Exists('$(ResoniteHotReloadPath)')" />
     <Copy SourceFiles="$(TargetPath)"
           DestinationFolder="$(ResoniteHotReloadPath)"
-          SkipUnchangedFiles="true"
           Condition="'$(Configuration)'=='Debug'" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- normalize `ResonitePath` with `EnsureTrailingSlash`
- simplify install target copy commands

## Testing
- `dotnet build --no-restore` *(fails: missing Resonite dependencies)*