### PR TITLE
Add Codex setup and static formatting check

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,2 @@
+Programmatic checks:
+- `dotnet csharpier --check .`

--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install csharpier for formatting checks
+export PATH="$PATH:$HOME/.dotnet/tools"
+
+dotnet tool install --tool-path "$HOME/.dotnet/tools" csharpier || \
+  dotnet tool update --tool-path "$HOME/.dotnet/tools" csharpier

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "csharpier": {
+      "version": "0.24.4",
+      "commands": ["csharpier"]
+    }
+  }
+}

--- a/.github/workflows/static-check.yml
+++ b/.github/workflows/static-check.yml
@@ -1,0 +1,29 @@
+name: Static Checks
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - ci
+      - ci/*
+  pull_request:
+    branches:
+      - master
+      - main
+      - ci
+      - ci/*
+
+jobs:
+  csharpier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install csharpier
+        run: dotnet tool install -g csharpier
+      - name: Run csharpier check
+        run: $HOME/.dotnet/tools/csharpier --check .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agents Instructions
+
+The CI workflow uses static checks that do not require Resonite assemblies.
+
+- Formatting is enforced with `csharpier`.
+- Before committing, run `dotnet csharpier --check .` to verify formatting.
+- TODO: Explore additional static checks such as `dotnet format` with stub assemblies.


### PR DESCRIPTION
## Summary
- document csharpier usage in AGENTS file
- add Codex setup script installing csharpier
- add workflow to run csharpier
- track dotnet tool manifest

## Testing
- `dotnet csharpier --check .` *(fails: tool not installed)*