### PR TITLE
Fix release skipping condition

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Check if tag exists
       id: check_tag
       run: |
-        echo "TagExists=$(git tag -l "v${{ steps.get_version.outputs.Version }}")" >> $GITHUB_OUTPUT
+        echo "TagExists=$(git tag -l v${{ steps.get_version.outputs.Version }})" >> $GITHUB_OUTPUT
     outputs:
       should_release: ${{ steps.check_tag.outputs.TagExists == '' }}
       version: ${{ steps.get_version.outputs.Version }}


### PR DESCRIPTION
## Summary
- correct the tag existence check in CI workflow so releases are skipped when a matching tag already exists

## Testing
- `dotnet dotnet-csharpier --check .`